### PR TITLE
[Feature] Switch to UI DSL v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+- Switched to UI DSL v2.
 
 ## [0.3.0]
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ pluginVersion = 0.3.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 213
-pluginUntilBuild = 222.*
+pluginUntilBuild = 223.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension
 platformType = IC

--- a/src/main/kotlin/dev/willebrands/intellij/sloppyfocus/settings/SloppyFocusSettingsConfigurable.kt
+++ b/src/main/kotlin/dev/willebrands/intellij/sloppyfocus/settings/SloppyFocusSettingsConfigurable.kt
@@ -2,8 +2,11 @@ package dev.willebrands.intellij.sloppyfocus.settings
 
 import com.intellij.openapi.options.BoundConfigurable
 import com.intellij.openapi.ui.DialogPanel
-import com.intellij.ui.layout.panel
+import com.intellij.ui.dsl.builder.bindIntText
+import com.intellij.ui.dsl.builder.buttonGroup
+import com.intellij.ui.dsl.builder.panel
 
+@Suppress("UnstableApiUsage")
 class SloppyFocusSettingsConfigurable : BoundConfigurable(
     "Sloppy Focus Settings"
 ) {
@@ -12,20 +15,20 @@ class SloppyFocusSettingsConfigurable : BoundConfigurable(
 
     override fun createPanel(): DialogPanel {
         return panel {
-            row {
-                label("Focus change delay (ms)")
-                intTextField(settings::focusDelayMs)
+            row("Focus change delay (ms)") {
+                intTextField(0..Int.MAX_VALUE, 25).bindIntText(settings::focusDelayMs)
             }
-            titledRow("Focus Target Selection") {
+            buttonGroup(
+                settings::focusEditorAndTerminalOnly,
+                "Focus Target Selection"
+            ) {
                 row {
-                    buttonGroup {
-                        row {
-                            radioButton("Switch focus to any focusable component")
-                        }
-                        row {
-                            radioButton("Limit focus switching to editors and terminals", settings::focusEditorAndTerminalOnly)
-                        }
-                    }
+                    radioButton("Switch focus to any focusable component", false)
+                }
+                row {
+                    radioButton(
+                        "Limit focus switching to editors and terminals", true
+                    )
                 }
             }
         }


### PR DESCRIPTION
Replaces removed method in 2022.3. Will need to drop 2021.3 compatibility to replace `buttonGroup` with `buttonsGroup` or find an alternative.