### PR TITLE
[Feature] 2023.2 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- Bump compatibility range to include 2023.2
+
 ## [0.4.0] - 2022-12-12
 
 ### Changed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,9 +7,9 @@ plugins {
     // Java support
     id("java")
     // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.7.21"
+    id("org.jetbrains.kotlin.jvm") version "1.8.20"
     // Gradle IntelliJ Plugin
-    id("org.jetbrains.intellij") version "1.10.0"
+    id("org.jetbrains.intellij") version "1.13.3"
     // Gradle Changelog Plugin
     id("org.jetbrains.changelog") version "2.0.0"
     // Gradle Qodana Plugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ platformVersion = 2021.3.3
 platformPlugins =
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 7.5.1
+gradleVersion = 8.1
 
 # Opt-out flag for bundling Kotlin standard library -> https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library
 # suppress inspection "UnusedProperty"

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,11 +4,11 @@ pluginGroup = dev.willebrands.intellij
 pluginName = sloppy-focus
 pluginRepositoryUrl = https://github.com/jwillebrands/ij-sloppy-focus
 # SemVer format -> https://semver.org
-pluginVersion = 0.4.0
+pluginVersion = 0.4.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 213
-pluginUntilBuild = 223.*
+pluginUntilBuild = 232.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension
 platformType = IC


### PR DESCRIPTION
The scheduled for removal UI DSL API still seems to be present, so putting off dropping earlier IntelliJ version compatibility for a little longer.