### PR TITLE
improve popup detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Improved popup detection. Before only the ActionManager popup stack was checked. Now we also check whether
+  the `PopupFactory` is aware of any active popups. This should prevent more popups (e.g. new Angular schematic) from
+  being auto-closed due to switching focus.
+
 ## [0.4.1] - 2023-05-16
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = dev.willebrands.intellij
 pluginName = sloppy-focus
 pluginRepositoryUrl = https://github.com/jwillebrands/ij-sloppy-focus
 # SemVer format -> https://semver.org
-pluginVersion = 0.4.1
+pluginVersion = 0.5.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 213

--- a/src/main/kotlin/dev/willebrands/intellij/sloppyfocus/SloppyFocusSwitcher.kt
+++ b/src/main/kotlin/dev/willebrands/intellij/sloppyfocus/SloppyFocusSwitcher.kt
@@ -2,6 +2,7 @@ package dev.willebrands.intellij.sloppyfocus
 
 import com.intellij.openapi.application.ModalityState
 import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.trace
 import com.intellij.openapi.project.Project
 import com.intellij.util.Alarm
 import dev.willebrands.intellij.sloppyfocus.filters.ComponentTypeFilters
@@ -27,7 +28,7 @@ class SloppyFocusSwitcher(private val project: Project) : ComponentMouseListener
         }
 
     override fun mouseEntered(event: ComponentMouseEvent) {
-        pluginLogger.debug("mouse entered ${event.component.javaClass.name}")
+        pluginLogger.trace { "mouse entered ${event.component.javaClass.name}" }
         if (componentFilter.test(event.component)) {
             focusSwitcherAlarm.cancelAllRequests()
             focusSwitcherAlarm.addRequest({ switchFocus(event.component) }, focusDelay, ModalityState.NON_MODAL)
@@ -35,7 +36,7 @@ class SloppyFocusSwitcher(private val project: Project) : ComponentMouseListener
     }
 
     override fun mouseExited(event: ComponentMouseEvent) {
-        pluginLogger.debug("mouse exited ${event.component.javaClass.name}")
+        pluginLogger.trace { "mouse exited ${event.component.javaClass.name}" }
         focusSwitcherAlarm.cancelAllRequests()
     }
 

--- a/src/main/kotlin/dev/willebrands/intellij/sloppyfocus/util/Logging.kt
+++ b/src/main/kotlin/dev/willebrands/intellij/sloppyfocus/util/Logging.kt
@@ -2,6 +2,13 @@ package dev.willebrands.intellij.sloppyfocus.util
 
 import com.intellij.openapi.diagnostic.Logger
 
+private const val pluginCategory = "dev.willebrands.intellij.sloppyfocus"
+private val componentLoggers = mutableMapOf<String, Logger>()
+
 val pluginLogger: Logger by lazy {
-    Logger.getInstance("dev.willebrands.intellij.sloppyfocus")
+    Logger.getInstance(pluginCategory)
 }
+
+fun componentLogger(component: String): Logger = componentLoggers.computeIfAbsent(
+    component
+) { Logger.getInstance("$pluginCategory.$component") }

--- a/src/main/kotlin/dev/willebrands/intellij/sloppyfocus/veto/Logging.kt
+++ b/src/main/kotlin/dev/willebrands/intellij/sloppyfocus/veto/Logging.kt
@@ -1,0 +1,10 @@
+package dev.willebrands.intellij.sloppyfocus.veto
+
+import com.intellij.openapi.diagnostic.debug
+import dev.willebrands.intellij.sloppyfocus.util.componentLogger
+
+fun logVetoDecision(allowSwitch: Boolean, messageProvider: () -> String) {
+    componentLogger("veto").debug {
+        "Focus switch ${if (allowSwitch) "allowed" else "vetoed"}: ${messageProvider()}"
+    }
+}

--- a/src/main/kotlin/dev/willebrands/intellij/sloppyfocus/veto/PopupMenuStateVetoableFocusListener.kt
+++ b/src/main/kotlin/dev/willebrands/intellij/sloppyfocus/veto/PopupMenuStateVetoableFocusListener.kt
@@ -2,10 +2,17 @@ package dev.willebrands.intellij.sloppyfocus.veto
 
 import com.intellij.openapi.actionSystem.ex.ActionManagerEx
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.popup.JBPopupFactory
 import java.awt.Component
 
 class PopupMenuStateVetoableFocusListener : VetoableFocusSwitchListener {
     override fun allowFocusSwitch(target: Component, project: Project): Boolean {
-        return ActionManagerEx.getInstanceEx().isActionPopupStackEmpty
+        val actionPopupStackEmpty = ActionManagerEx.getInstanceEx().isActionPopupStackEmpty
+        val popupActive = JBPopupFactory.getInstance().isPopupActive
+        val allowFocusSwitch = actionPopupStackEmpty && !popupActive
+        logVetoDecision(allowFocusSwitch) {
+            "Action popup stack empty = $actionPopupStackEmpty; popup active = $popupActive"
+        }
+        return allowFocusSwitch
     }
 }


### PR DESCRIPTION
Use `JBPopupFactory` to determine whether a popup is active instead of relying on ActionManager's action stack. The latter can probably be removed as it's likely covered by the PopupFactory. That requires further analysis though.

Release as 0.5.0