### PR TITLE
chore: do not enforce an upper build limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- Stop enforcing an upper limit for IDEA version.
+
 ## [0.9.0] - 2024-08-07
 
 ### Changed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,7 +84,7 @@ intellijPlatform {
 
         ideaVersion {
             sinceBuild = providers.gradleProperty("pluginSinceBuild")
-            untilBuild = providers.gradleProperty("pluginUntilBuild")
+            untilBuild = provider { null }
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = dev.willebrands.intellij
 pluginName = sloppy-focus
 pluginRepositoryUrl = https://github.com/jwillebrands/ij-sloppy-focus
 # SemVer format -> https://semver.org
-pluginVersion = 0.9.0
+pluginVersion = 0.9.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 232

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,6 @@ pluginVersion = 0.9.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 232
-pluginUntilBuild = 242.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension
 platformType = IC


### PR DESCRIPTION
Remove the explicit `untilBuild`. It should work until it doesn't.